### PR TITLE
Use lowercase "windows.h".

### DIFF
--- a/salad.c
+++ b/salad.c
@@ -36,7 +36,7 @@
 
 #if defined(_WIN32)
 #define WIN32_LEAN_AND_MEAN 1
-#include <Windows.h>
+#include <windows.h>
 
 #define OPENAL_LIBNAME "OpenAL32.dll"
 


### PR DESCRIPTION
Fixes cross compilation.